### PR TITLE
Fix spacing in Agenda to correctly display Table of Contents

### DIFF
--- a/topics/assembly/tutorials/hybrid_denovo_assembly/tutorial.md
+++ b/topics/assembly/tutorials/hybrid_denovo_assembly/tutorial.md
@@ -60,7 +60,6 @@ This Galaxy tutorial based on material from the [Hybrid genome assembly - Nanopo
 > In this tutorial we will deal with:
 >
 > 1. TOC
-> 
 > {:toc}
 >
 {: .agenda}


### PR DESCRIPTION
Removing extra line spacing in the Agenda section between "1. TOC" and "{:toc} so that the table of contents will be displayed correctly for the Hybrid Genome Assembly tutorial.

